### PR TITLE
Adding features from #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,100 +1,44 @@
 <p align="center"><img src="https://github.com/gabyfle/Lice/blob/main/lice_frame.png?raw=true" width="150px" style="margin: auto; border-radius: 200px;"></p>
 
 # Lice
-Lice language interpreter
+Lice language main repository. Contains all the library code of the Lice language and everything you need to add Lice to your OCaml application.
 
 ## What is Lice ?
 
 Lice is a little general purpose interpreted language. It's meant to be easy-to-learn when you know OCaml, C-like languages, and to be as easy to use as Lua.
 
-The Lice language doesn't aim to be super-fast neither to have super-extensible standard library. It's primary goal is to be easy to extend for OCaml developer: creating a library written in OCaml for Lice should not be a pain in the ass.
-
-## Why Lice ?
-
-The first goal of Lice is to have something that is embeddable inside any OCaml project and that have a well defined and robust OCaml API. The main inspiration for this is, of course, the Lua programming language and it's very clean and easy-to-use C-API that enables C programmers to ship Lua into their C program easily.
-
-As a long-term Lua developer and a newbie OCaml developer, I wanted to give a shot to this project and having a Lua-like language built directly into the OCaml ecosystem.
-
-This project is also a way to learn more things about the way programming languages are crafted and built, as well as an opportunity to make a language that I know perfectly without even having to learn it, as all of it's syntax is inspired by C, OCaml and Lua, and that I'm familiar with these three languages.
-
-## State of the project
-
-For the moment, this is the very beginning of the project, the parser should work but hasn't been well tested yet, and the surrounding elements of what makes an interpreter aren't yet implemented/do not work yet. The project is still in the "WIP" stage.
-
-Of course the ultimate goal, and also the primary feature of the language will be it's interoperability with OCaml, as well as its module system, to make OCaml developers able to build libraries for Lice in OCaml, but since we do not have something working yet, this will be in the last stage of the development.
-
 ## Features of the language
-    - Type annotations
-    - Recursive functions
-    - OCaml-like pattern matching
-    - Native lists
-    - Embedabble withing any OCaml application
+- Type annotations
+- Recursive functions
+- OCaml-like pattern matching
+- Native lists
+- Deconstructing inside pattern matching
+- Embedabble withing any OCaml application
+- First-class values functions
+- OCaml bindings to write your own applications
 
-## Example programs
+## Documentation
 
-Here are some example programs. Note that since the current stage of the project is still "WIP", this syntax may be subject to slight changes.
+### Installing the Lice language library
 
-#### Recursive power function
+To install the Lice language library, you'll need to have the `opam` dependency manager installed in your local system.
 
-This little snippet shows how you can compute x^n when n is an integer. It uses a recursive function as well as pattern matching in order to achieve the computation.
+The first step is to clone locally the repository. You can use this command line to clone throught `https`:
 
-```lua
---[[---------------------------
---    Recursive power func   --
---                           --
---    (this is a comment)    --
------------------------------]]
-
-function power(x: number, n: number, acc: number): number {
-    if (n == 0) return acc;
-    if (n == 1) return acc * x;
-
-    if ((n % 2) ~= 0) return power(x * x, (n - 1) / 2, x * acc);
-    else return power(x * x, n / 2, acc);
-}
-
-function main(): void {
-    let number x = 2;
-    let number n = 8;
-
-    let number p = power(x, n, 1);
-
-    return;
-}
-
-main();
+```bash
+git clone https://github.com/gabyfle/Lice.git
 ```
 
-#### Reverse a list
+Then, navigate to your freshly created `Lice` folder and run the `opam install` command at the root of the project:
 
-As you can see in this example, lists constructions are heavily inspired from the OCaml way of building and deconstructing lists. Here is a little snippet to show how you can reverse a list inside the Lice language.
-
-```lua
-function reverse_aux(l: list, acc: list): list {
-    match l with {
-        | [] -> return acc;
-        | h :: t -> return reverse_aux(t, h :: acc);
-    }
-}
-
-function reverse(l: list): list {
-    return reverse_aux(l, []);
-}
+```bash
+cd Lice
+opam install .
 ```
 
-#### Count to ten
+The Lice language library is now installed into your system.
 
-This program demonstrate how to count to ten using a recursive function. Note: if we're using recursive functions for the moment, it's because we don't have any loop system in the language.
-
-```lua
-function main(x) {
-    if (x == 10) { return x; }
-    main(x + 1);
-}
-
-main(0);
-
-```
+### Learning the Lice language
 
 ## Licence
 

--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,5 @@
 (executable
  (name lice)
  (public_name lice)
- (libraries kernel))
+ (libraries kernel)
+ (ocamlc_flags (-g)))

--- a/src/kernel/ast/tree.ml
+++ b/src/kernel/ast/tree.ml
@@ -37,6 +37,7 @@ type statement =
   | FuncDef of location * typed_ident * typed_ident list * statement
   | Match of location * expr * (expr * statement list) list
   | If of location * expr * statement * statement
+  | ModuleDef of location * identificator * statement list
 
 and program = statement list
 
@@ -63,6 +64,8 @@ let stmt_to_string = function
       "Pattern-matching"
   | If (_, _, _, _) ->
       "If statement"
+  | ModuleDef (_, _, _) ->
+      "Module definition"
 
 let bincomp_to_string = function
   | Equal ->

--- a/src/kernel/ast/tree.ml
+++ b/src/kernel/ast/tree.ml
@@ -25,19 +25,15 @@ open Types.Base
 
 type location = Lexing.position
 
-type identificator = string
-
-and typed_ident = identificator * typ
-
 type statement =
   | Return of location * expr
   | Expression of location * expr * typ
   | Block of location * statement list
-  | Assign of location * typed_ident * expr
-  | FuncDef of location * typed_ident * typed_ident list * statement
+  | Assign of location * identificator * expr
+  | FuncDef of location * identificator * identificator list * statement
   | Match of location * expr * (expr * statement list) list
   | If of location * expr * statement * statement
-  | ModuleDef of location * identificator * statement list
+  | ModuleDef of location * ident * statement list
 
 and program = statement list
 

--- a/src/kernel/ast/tree.mli
+++ b/src/kernel/ast/tree.mli
@@ -25,19 +25,15 @@ open Types.Base
 
 type location = Lexing.position
 
-type identificator = string
-
-and typed_ident = identificator * typ
-
 type statement =
   | Return of location * expr
   | Expression of location * expr * typ
   | Block of location * statement list
-  | Assign of location * typed_ident * expr
-  | FuncDef of location * typed_ident * typed_ident list * statement
+  | Assign of location * identificator * expr
+  | FuncDef of location * identificator * identificator list * statement
   | Match of location * expr * (expr * statement list) list
   | If of location * expr * statement * statement
-  | ModuleDef of location * identificator * statement list
+  | ModuleDef of location * ident * statement list
 
 and program = statement list
 

--- a/src/kernel/ast/tree.mli
+++ b/src/kernel/ast/tree.mli
@@ -37,6 +37,7 @@ type statement =
   | FuncDef of location * typed_ident * typed_ident list * statement
   | Match of location * expr * (expr * statement list) list
   | If of location * expr * statement * statement
+  | ModuleDef of location * identificator * statement list
 
 and program = statement list
 

--- a/src/kernel/env.ml
+++ b/src/kernel/env.ml
@@ -21,6 +21,7 @@
 (*****************************************************************************)
 
 open Ast.Tree
+open Types.Base
 open Utils
 open Utils.Logger
 
@@ -29,13 +30,15 @@ module type SCOPE = sig
 
   val create : unit -> t
 
-  val get : t -> string -> statement option
+  val get : t -> identificator -> statement option
 
-  val set : t -> string -> statement -> t
+  val set : t -> identificator -> statement -> t
 
   val push_scope : t -> t
 
   val pop_scope : t -> t
+
+  val add_module : t -> string -> t
 
   val dump : t -> unit
 end
@@ -48,54 +51,122 @@ end
 
 module Table = Map.Make (Identificator)
 
-module Scope = struct
-  type tbl = statement Table.t
+let get_name (n : identificator) =
+  match n with `Ident s -> s | `Module (_, s) -> s
 
-  type t = tbl list
+let get_module (n : identificator) =
+  match n with `Ident _ -> None | `Module (m, _) -> Some m
+
+module Scope = struct
+  type scp = statement Table.t
+
+  type md = statement Table.t Table.t
+
+  and t = (scp * md) list
 
   let create () : t = []
 
   let dump (env : t) =
+    let display_modules e =
+      let iter k s =
+        Printf.printf "Module: %s\n" k ;
+        Table.iter
+          (fun k s ->
+            Printf.printf "Key: %s \nValue: %s \n\n" k
+              (Formatting.stmt_format s) )
+          s
+      in
+      Table.iter iter e
+    in
     let rec aux = function
       | [] ->
           ()
-      | h :: t ->
+      | (scp, md) :: t ->
           let iter k s =
             Printf.printf "Key: %s \nValue: %s \n\n" k
               (Formatting.stmt_format s)
           in
-          Table.iter iter h ; aux t
+          Table.iter iter scp ; display_modules md ; aux t
     in
     Printf.printf "Scope DUMP: \n" ;
     aux env
 
   let get (env : t) (name : identificator) : statement option =
-    (*Logger.debug "Getting %s\n" name ;*)
-    let rec find_opt name = function
-      | [] ->
-          None
-      | h :: _ when Table.mem name h ->
-          Table.find_opt name h
-      | _ :: t ->
-          find_opt name t
-    in
-    find_opt name env
+    let md = get_module name in
+    let n = get_name name in
+    match md with
+    | Some m ->
+        let rec find_opt name = function
+          | [] ->
+              None
+          | (_, h) :: _ when Table.mem m h -> (
+              let md = Table.find_opt m h in
+              match md with Some m -> Table.find_opt name m | None -> None )
+          | _ :: t ->
+              find_opt name t
+        in
+        find_opt (fst n) env
+    | None ->
+        let rec find_opt name = function
+          | [] ->
+              None
+          | (h, _) :: _ when Table.mem name h ->
+              Table.find_opt name h
+          | _ :: t ->
+              find_opt name t
+        in
+        find_opt (fst n) env
 
-  let set (env : t) (name : string) (v : statement) : t =
-    Logger.debug "Setting %s to %s\n" name (Formatting.stmt_format v) ;
-    match env with
-    | [] ->
-        [Table.add name v Table.empty]
-    | h :: t ->
-        if Table.mem name h then
-          let updated = Table.add name v h in
-          updated :: t
-        else
-          let n = Table.add name v h in
-          n :: t
+  let add_module (env : t) (md_name : string) : t =
+    let exists = List.exists (fun (_, md) -> Table.mem md_name md) env in
+    if exists then
+      raise (Failure (Printf.sprintf "Module %s already exists" md_name))
+    else
+      let md = Table.add md_name Table.empty Table.empty in
+      (Table.empty, md) :: env
+
+  (* sets a variable inside a given module *)
+  let set_module (env : t) (md_name : string) (name : string) (v : statement) :
+      t =
+    let rec aux = function
+      | [] ->
+          []
+      | (scp, md) :: t when Table.mem md_name md ->
+          (* we found the correct module so we can set the correct value for the
+             variable *)
+          let new_md = Table.add name v (Table.find md_name md) in
+          let md = Table.add md_name new_md md in
+          (scp, md) :: t
+      | h :: t ->
+          h :: aux t
+    in
+    aux env
+
+  let set (env : t) (name : identificator) (v : statement) : t =
+    let md = get_module name in
+    let n = get_name name in
+    Logger.debug "Setting %s to %s\n" (fst n) (Formatting.stmt_format v) ;
+    match md with
+    | Some m ->
+        (* the varible we're trying to set is inside a module *)
+        (* let's gets its name and call set_module *)
+        set_module env m (fst n) v
+    | None ->
+        (* the variable we're trying to set is not inside a module *)
+        (* let's find the correct scope and set the variable there *)
+        let rec aux = function
+          | [] ->
+              []
+          | (scp, md) :: t when Table.mem (fst n) scp ->
+              let new_scp = Table.add (fst n) v scp in
+              (new_scp, md) :: t
+          | h :: t ->
+              h :: aux t
+        in
+        aux env
 
   let push_scope (env : t) : t =
-    match env with [] -> [Table.empty] | h :: _ -> h :: env
+    match env with [] -> [(Table.empty, Table.empty)] | h :: _ -> h :: env
 
   let pop_scope (env : t) : t = match env with [] -> env | _ :: t -> t
 end

--- a/src/kernel/env.ml
+++ b/src/kernel/env.ml
@@ -70,7 +70,7 @@ module Scope = struct
     aux env
 
   let get (env : t) (name : identificator) : statement option =
-    Logger.debug "Getting %s\n" name ;
+    (*Logger.debug "Getting %s\n" name ;*)
     let rec find_opt name = function
       | [] ->
           None

--- a/src/kernel/env.ml
+++ b/src/kernel/env.ml
@@ -69,7 +69,7 @@ module Scope = struct
   let dump (env : t) =
     let display_modules e =
       let iter k s =
-        Printf.printf "Module: %s\n" k ;
+        Logger.debug "Module: %s\n" k ;
         Table.iter
           (fun k s ->
             Printf.printf "Key: %s \nValue: %s \n\n" k
@@ -83,12 +83,12 @@ module Scope = struct
           ()
       | (scp, md) :: t ->
           let iter k s =
-            Printf.printf "Key: %s \nValue: %s \n\n" k
+            Logger.debug "Key: %s \nValue: %s \n\n" k
               (Formatting.stmt_format s)
           in
           Table.iter iter scp ; display_modules md ; aux t
     in
-    Printf.printf "Scope DUMP: \n" ;
+    Logger.debug "Scope DUMP: \n" ;
     aux env
 
   let get (env : t) (name : identificator) : statement option =
@@ -143,9 +143,9 @@ module Scope = struct
     aux env
 
   let set (env : t) (name : identificator) (v : statement) : t =
+    Logger.debug "Setting %s\n to %s" (identificator_to_string name) (Formatting.stmt_format v);
     let md = get_module name in
     let n = get_name name in
-    Logger.debug "Setting %s to %s\n" (fst n) (Formatting.stmt_format v) ;
     match md with
     | Some m ->
         (* the varible we're trying to set is inside a module *)
@@ -156,7 +156,7 @@ module Scope = struct
         (* let's find the correct scope and set the variable there *)
         let rec aux = function
           | [] ->
-              []
+              [Table.add (fst n) v Table.empty, Table.empty]
           | (scp, md) :: t when Table.mem (fst n) scp ->
               let new_scp = Table.add (fst n) v scp in
               (new_scp, md) :: t

--- a/src/kernel/env.ml
+++ b/src/kernel/env.ml
@@ -83,8 +83,7 @@ module Scope = struct
           ()
       | (scp, md) :: t ->
           let iter k s =
-            Logger.debug "Key: %s \nValue: %s \n\n" k
-              (Formatting.stmt_format s)
+            Logger.debug "Key: %s \nValue: %s \n\n" k (Formatting.stmt_format s)
           in
           Table.iter iter scp ; display_modules md ; aux t
     in
@@ -92,16 +91,25 @@ module Scope = struct
     aux env
 
   let get (env : t) (name : identificator) : statement option =
+    Logger.debug "Getting %s\n" (identificator_to_string name) ;
     let md = get_module name in
     let n = get_name name in
+    Logger.debug "Module: %s\n" (Option.value ~default:"None" md) ;
+    Logger.debug "Name: %s\n" (fst n) ;
+    Logger.debug "DUMPING EVERYTHING\n" ;
+    dump env ;
+    Logger.debug "DUMPING EVERYTHING\n" ;
     match md with
     | Some m ->
+        (* the varible we're trying to get is inside a module *)
+        (* let's gets its name and call set_module *)
         let rec find_opt name = function
           | [] ->
               None
           | (_, h) :: _ when Table.mem m h -> (
+              Printf.printf "found_module akjhbfdaiezjhfgaezijhofg" ;
               let md = Table.find_opt m h in
-              match md with Some m -> Table.find_opt name m | None -> None )
+              match md with Some m -> Printf.printf "found_module"; Table.find_opt name m | None -> None )
           | _ :: t ->
               find_opt name t
         in
@@ -130,7 +138,8 @@ module Scope = struct
       t =
     let rec aux = function
       | [] ->
-          []
+          [ ( Table.empty
+            , Table.add md_name (Table.add name v Table.empty) Table.empty ) ]
       | (scp, md) :: t when Table.mem md_name md ->
           (* we found the correct module so we can set the correct value for the
              variable *)
@@ -143,20 +152,28 @@ module Scope = struct
     aux env
 
   let set (env : t) (name : identificator) (v : statement) : t =
-    Logger.debug "Setting %s\n to %s" (identificator_to_string name) (Formatting.stmt_format v);
+    Logger.debug "Setting %s\n to %s"
+      (identificator_to_string name)
+      (Formatting.stmt_format v) ;
     let md = get_module name in
     let n = get_name name in
     match md with
     | Some m ->
+        Logger.warning "Setting %s\n to %s"
+          (identificator_to_string name)
+          (Formatting.stmt_format v) ;
         (* the varible we're trying to set is inside a module *)
         (* let's gets its name and call set_module *)
         set_module env m (fst n) v
     | None ->
+        Logger.error "Setting %s\n to %s"
+          (identificator_to_string name)
+          (Formatting.stmt_format v) ;
         (* the variable we're trying to set is not inside a module *)
         (* let's find the correct scope and set the variable there *)
         let rec aux = function
           | [] ->
-              [Table.add (fst n) v Table.empty, Table.empty]
+              [(Table.add (fst n) v Table.empty, Table.empty)]
           | (scp, md) :: t when Table.mem (fst n) scp ->
               let new_scp = Table.add (fst n) v scp in
               (new_scp, md) :: t

--- a/src/kernel/env.mli
+++ b/src/kernel/env.mli
@@ -21,19 +21,22 @@
 (*****************************************************************************)
 
 open Ast.Tree
+open Types.Base
 
 module type SCOPE = sig
   type t
 
   val create : unit -> t
 
-  val get : t -> string -> statement option
+  val get : t -> identificator -> statement option
 
-  val set : t -> string -> statement -> t
+  val set : t -> identificator -> statement -> t
 
   val push_scope : t -> t
 
   val pop_scope : t -> t
+
+  val add_module : t -> string -> t
 
   val dump : t -> unit
 end

--- a/src/kernel/eval.ml
+++ b/src/kernel/eval.ml
@@ -25,7 +25,6 @@ open Types
 open Types.Base
 open Env
 open Located_error
-open Utils.Logger
 
 module type EVAL = sig
   val exec : program -> unit
@@ -64,7 +63,6 @@ module Eval : EVAL = struct
           raise (Located_error (`Language_Error str, loc)) )
 
   let rec binop_helper env loc v v' op =
-    Logger.debug "binop_helper" ;
     let aux a b op =
       let value =
         match op with
@@ -395,7 +393,6 @@ module Eval : EVAL = struct
 
   and eval_statement env = function
     | Return (loc, e) ->
-        Utils.Logger.Logger.debug "Return statement found" ;
         (env, Return (loc, e)) (* Wrap the expression in a Return statement *)
     | Expression (loc, e, _typ) ->
         let env, expr = eval_expr env loc (env, e) in

--- a/src/kernel/eval.ml
+++ b/src/kernel/eval.ml
@@ -210,7 +210,7 @@ module Eval : EVAL = struct
         let tmp', v_b = eval_expr tmp loc ~in_mod (tmp, b) in
         bincomp_helper tmp' loc ~in_mod v_a v_b
 
-  and cons_helper env loc ?(in_mod=None) a b =
+  and cons_helper env loc ?(in_mod = None) a b =
     match (a, b) with
     | Terminal (V_Var id), (Terminal (V_Var _) as k') -> (
         let value = get_value env loc id in

--- a/src/kernel/eval.ml
+++ b/src/kernel/eval.ml
@@ -429,6 +429,7 @@ module Eval : EVAL = struct
           in
           (n_env, Expression (loc, Terminal (Const V_Void), T_Void))
     | FuncDef (_, id, _, _) as f ->
+        Scope.dump env;
         (Scope.set env id f, f) (* Return the function definition statement *)
     | Match (loc, pattern, cases) ->
         let env, stmt = eval_match env loc (env, pattern) cases in

--- a/src/kernel/eval.ml
+++ b/src/kernel/eval.ml
@@ -440,6 +440,8 @@ module Eval : EVAL = struct
             if b then eval_statement n_env t else eval_statement n_env f
         | _ ->
             raise (Located_error (`Wrong_Type (T_Boolean, T_Auto), loc)) )
+    | ModuleDef (loc, _, _) ->
+        (env, Expression (loc, Terminal (Const V_Void), T_Void))
   (* for the moment we're not getting the type of the expression *)
 
   let exec (p : program) =

--- a/src/kernel/lexer.mll
+++ b/src/kernel/lexer.mll
@@ -38,6 +38,8 @@
               "with", WITH;
               "if", IF;
               "else", ELSE;
+              "open", OPEN;
+              "module", MODULE;
               "true", BOOLEAN(true);
               "false", BOOLEAN(false);]
 
@@ -77,6 +79,7 @@ rule token = parse
   | '}'             { RBRACE }
   | ';'             { SEMICOLON }
   | ':'             { COLON }
+  | '.'             { DOT }
   | '|'             { PIPE }
   | '_'             { WILDCARD }
   | "->"            { ARROW }

--- a/src/kernel/located_error.ml
+++ b/src/kernel/located_error.ml
@@ -78,7 +78,7 @@ let handle_type_exception f a b =
       let str =
         Formatting.misc_error loc "Using an undefined variable of name "
       in
-      Logger.error "%s %s" str id ;
+      Logger.error "%s %s" str (identificator_to_string id) ;
       exit 1
   | Located_error (`Op_Mismatch (op, a, b), loc) ->
       let str =
@@ -104,7 +104,9 @@ let handle_type_exception f a b =
       in
       Logger.error "%s" str ; exit 1
   | Located_error (`Wrong_Parameters_Number (fname, a, b), loc) ->
-      let str = Formatting.params_number_error loc fname a b in
+      let str =
+        Formatting.params_number_error loc (identificator_to_string fname) a b
+      in
       Logger.error "%s" str ; exit 1
   | Located_error (`Wrong_Parameter_Type (_, a, b), loc)
   | Located_error (`Wrong_Assign_Type (_, a, b), loc)

--- a/src/kernel/parser.mly
+++ b/src/kernel/parser.mly
@@ -250,8 +250,8 @@ let module_body :=
   { stmts }
 
 let module_def := 
-  | MODULE; _p = IDENT; _b = module_body;
-  { (Expression($startpos, Terminal(Const(V_Void)), T_Void)) }
+  | MODULE; id = IDENT; b = module_body;
+  { ModuleDef($startpos, id, b) }
 
 let statement ==
   | p = expr; SEMICOLON; EOL*; { Expression ($startpos, p, T_Auto) }

--- a/src/kernel/types/base.ml
+++ b/src/kernel/types/base.ml
@@ -33,12 +33,14 @@ type typed_ident = ident * typ
 
 and typ = T_Number | T_String | T_List | T_Boolean | T_Auto | T_Void
 
+type identificator = [`Ident of typed_ident | `Module of ident * typed_ident]
+
 type expr =
   | Terminal of value
   | BinOp of binop_type * expr * expr
-  | FuncCall of ident * expr list
+  | FuncCall of identificator * expr list
 
-and value = Const of t | V_Var of typed_ident
+and value = Const of t | V_Var of identificator
 
 and t =
   | V_Number of Lnumber.t
@@ -46,6 +48,12 @@ and t =
   | V_List of expr list
   | V_Boolean of Lbool.t
   | V_Void
+
+let identificator_to_string = function
+  | `Ident (id, _) ->
+      id
+  | `Module (m, (id, _)) ->
+      m ^ "." ^ id
 
 let bincomp_to_string = function
   | Equal ->

--- a/src/kernel/types/base.mli
+++ b/src/kernel/types/base.mli
@@ -33,12 +33,14 @@ type typed_ident = ident * typ
 
 and typ = T_Number | T_String | T_List | T_Boolean | T_Auto | T_Void
 
+type identificator = [`Ident of typed_ident | `Module of ident * typed_ident]
+
 type expr =
   | Terminal of value
   | BinOp of binop_type * expr * expr
-  | FuncCall of ident * expr list
+  | FuncCall of identificator * expr list
 
-and value = Const of t | V_Var of typed_ident
+and value = Const of t | V_Var of identificator
 
 and t =
   | V_Number of Lnumber.t
@@ -46,6 +48,8 @@ and t =
   | V_List of expr list
   | V_Boolean of Lbool.t
   | V_Void
+
+val identificator_to_string : identificator -> string
 
 val bincomp_to_string : binary_comp -> string
 

--- a/src/kernel/types/llist.ml
+++ b/src/kernel/types/llist.ml
@@ -55,12 +55,14 @@ module S = struct
             in
             aux ppf l
           in
-          Format.fprintf ppf "%s(%a)" id pretty_list l
+          Format.fprintf ppf "%s(%a)"
+            (Base.identificator_to_string id)
+            pretty_list l
     and pretty_val ppf = function
       | Base.Const t ->
           pretty_base ppf t
-      | Base.V_Var (id, _) ->
-          Format.fprintf ppf "%s" id
+      | Base.V_Var id ->
+          Format.fprintf ppf "%s" (Base.identificator_to_string id)
     and pretty_base ppf = function
       | Base.V_Number n ->
           Lnumber.pretty ppf n
@@ -96,8 +98,12 @@ module S = struct
       match (v, v') with
       | Base.Const t, Base.Const t' ->
           compare_base t t'
-      | Base.V_Var (id, _), Base.V_Var (id', _) ->
+      | Base.V_Var id, Base.V_Var id' ->
+          let id = Base.identificator_to_string id in
+          let id' = Base.identificator_to_string id' in
           String.compare id id'
+          (* we're just checking if we're talking about the same variables
+             here *)
       | _ ->
           0
     and compare_base v v' =

--- a/src/kernel/types/value.ml
+++ b/src/kernel/types/value.ml
@@ -67,7 +67,7 @@ let get_typ_from_id = function
       t
 
 let typed_ident_list_to_id : typed_ident list -> identificator list =
-    List.map (fun ((name, typ)) -> `Ident ((name, typ)))
+  List.map (fun (name, typ) -> `Ident (name, typ))
 
 let name = function
   | V_Number _ ->

--- a/src/kernel/types/value.ml
+++ b/src/kernel/types/value.ml
@@ -38,7 +38,12 @@ let to_typ v =
     | V_Void ->
         T_Void
   in
-  let from_val = function Const c -> from_t c | V_Var (_, c) -> c in
+  let from_val = function
+    | Const c ->
+        from_t c
+    | V_Var id -> (
+      match id with `Ident (_n, t) -> t | `Module (_id, (_n, t)) -> t )
+  in
   from_val v
 
 let typ_to_string = function
@@ -54,6 +59,15 @@ let typ_to_string = function
       "auto"
   | T_Void ->
       "void"
+
+let get_typ_from_id = function
+  | `Ident (_n, t) ->
+      t
+  | `Module (_id, (_n, t)) ->
+      t
+
+let typed_ident_list_to_id : typed_ident list -> identificator list =
+    List.map (fun ((name, typ)) -> `Ident ((name, typ)))
 
 let name = function
   | V_Number _ ->

--- a/src/kernel/types/value.mli
+++ b/src/kernel/types/value.mli
@@ -28,6 +28,10 @@ val to_typ : value -> typ
 
 val typ_to_string : typ -> string
 
+val get_typ_from_id : identificator -> typ
+
+val typed_ident_list_to_id : typed_ident list -> identificator list
+
 val name : t -> string
 
 val pretty : Format.formatter -> t -> unit

--- a/src/kernel/utils/formatting.ml
+++ b/src/kernel/utils/formatting.ml
@@ -50,8 +50,8 @@ let expr_format expr =
       match t with
       | Const c ->
           Format.asprintf "%a" Value.pretty c
-      | V_Var (id, _) ->
-          Printf.sprintf "Variable: %s\n" id )
+      | V_Var id ->
+          Printf.sprintf "Variable: %s\n" (Base.identificator_to_string id) )
     | BinOp (binop_t, e, e') ->
         let bin =
           match binop_t with
@@ -70,7 +70,9 @@ let expr_format expr =
         (* bad functionnal code *)
         let iter e = t := !t ^ ";" ^ aux e in
         List.iter iter expr_list ;
-        Printf.sprintf "Function call ID: %s; Expression list: %s\n" id !t
+        Printf.sprintf "Function call ID: %s; Expression list: %s\n"
+          (Base.identificator_to_string id)
+          !t
   in
   aux expr
 
@@ -87,12 +89,14 @@ let stmt_format stmt =
         let iter e = t := !t ^ aux e in
         List.iter iter stmt_list ;
         Printf.sprintf "Block statement with statements: %s\n\n" !t
-    | Assign (_, (id, _), e) ->
-        Printf.sprintf "Assign statement id %s with expression %s\n\n" id
+    | Assign (_, id, e) ->
+        Printf.sprintf "Assign statement id %s with expression %s\n\n"
+          (Base.identificator_to_string id)
           (expr_format e)
-    | FuncDef (_, (name, _), _, def) ->
+    | FuncDef (_, id, _, def) ->
         let t = aux def in
-        Printf.sprintf "Function definition id: %s and definition: %s\n\n" name
+        Printf.sprintf "Function definition id: %s and definition: %s\n\n"
+          (Base.identificator_to_string id)
           t
     | Match (_, to_match, patterns) ->
         let str_match = expr_format to_match in

--- a/src/kernel/utils/formatting.ml
+++ b/src/kernel/utils/formatting.ml
@@ -111,6 +111,12 @@ let stmt_format stmt =
     | If (_, e, t, f) ->
         Printf.sprintf "If statement on condition %s. If true: %s if false: %s"
           (expr_format e) (aux t) (aux f)
+    | ModuleDef (_, name, stmts) ->
+        let tmp = ref "" in
+        let iter s = tmp := !tmp ^ aux s in
+        List.iter iter stmts ;
+        Printf.sprintf "Module definition id: %s and definition: %s\n\n" name
+          !tmp
   in
   aux stmt
 

--- a/src/lice.ml
+++ b/src/lice.ml
@@ -31,7 +31,7 @@ let () =
         (* Get the directory containing the executable *)
         let exec_dir = Filename.dirname exec_path in
         (* Construct the full path to the test file *)
-        Filename.concat exec_dir "tests/pattern/deconstruct.lice"
+        Filename.concat exec_dir "tests/modules/basic.lice"
     | _ ->
         failwith "Invalid command line arguments"
   in

--- a/src/lice.ml
+++ b/src/lice.ml
@@ -45,7 +45,7 @@ let () =
   let code_lines = read_code [] in
   close_in in_channel ;
   let code = String.concat "\n" code_lines in
-  Logger.set_level ["Debug"; "Info"; "Error"] ;
+  Logger.set_level ["Debug"; "Warning"; "Info"; "Error"] ;
   let ast = parse_code code in
   try
     let t r = r in

--- a/src/lice.ml
+++ b/src/lice.ml
@@ -45,7 +45,7 @@ let () =
   let code_lines = read_code [] in
   close_in in_channel ;
   let code = String.concat "\n" code_lines in
-  Logger.set_level ["Info"; "Error"] ;
+  Logger.set_level ["Debug"; "Info"; "Error"] ;
   let ast = parse_code code in
   try
     let t r = r in

--- a/src/lice.ml
+++ b/src/lice.ml
@@ -31,7 +31,7 @@ let () =
         (* Get the directory containing the executable *)
         let exec_dir = Filename.dirname exec_path in
         (* Construct the full path to the test file *)
-        Filename.concat exec_dir "tests/modules/basic.lice"
+        Filename.concat exec_dir "tests/perf/exp.lice"
     | _ ->
         failwith "Invalid command line arguments"
   in
@@ -45,7 +45,7 @@ let () =
   let code_lines = read_code [] in
   close_in in_channel ;
   let code = String.concat "\n" code_lines in
-  Logger.set_level ["Debug"; "Info"; "Error"] ;
+  Logger.set_level ["Info"; "Error"] ;
   let ast = parse_code code in
   try
     let t r = r in

--- a/src/lice.ml
+++ b/src/lice.ml
@@ -31,7 +31,7 @@ let () =
         (* Get the directory containing the executable *)
         let exec_dir = Filename.dirname exec_path in
         (* Construct the full path to the test file *)
-        Filename.concat exec_dir "tests/perf/exp.lice"
+        Filename.concat exec_dir "tests/modules/basic.lice"
     | _ ->
         failwith "Invalid command line arguments"
   in

--- a/tests/modules/basic.lice
+++ b/tests/modules/basic.lice
@@ -2,11 +2,13 @@ module Testing {
     let string t = "this is a test";
 
     function testing() {
-        return Testing.t;
+        let a = "hello";
+
+        return a;
     }
 
     function test2() {
-        return Testing.testing();
+        return testing() + t;
     }
 }
 

--- a/tests/modules/basic.lice
+++ b/tests/modules/basic.lice
@@ -1,11 +1,13 @@
-
 module Testing {
     let string t = "this is a test";
 
-    function test() {
-        return "test";
+    function testing() {
+        return Testing.t;
+    }
+
+    function test2() {
+        return Testing.testing();
     }
 }
 
-let testing_d = Testing.t;
-let md = Testing.test();
+let d = Testing.test2();

--- a/tests/modules/basic.lice
+++ b/tests/modules/basic.lice
@@ -3,6 +3,9 @@ module Testing {
     let string t = "this is a test";
 
     function test() {
-        return test;
+        return "test";
     }
 }
+
+let testing_d = Testing.t;
+let md = Testing.test();

--- a/tests/modules/basic.lice
+++ b/tests/modules/basic.lice
@@ -1,0 +1,8 @@
+
+module Testing {
+    let string t = "this is a test";
+
+    function test() {
+        return test;
+    }
+}

--- a/tests/perf/exp.lice
+++ b/tests/perf/exp.lice
@@ -13,4 +13,4 @@ function exp(n) {
     return exp_aux(n, 1);    
 }
 
-let number f = exp(3000);
+let number f = exp(300);

--- a/tests/perf/exp.lice
+++ b/tests/perf/exp.lice
@@ -1,0 +1,16 @@
+function factorial(n) {
+    if (n == 0) return 1;
+
+    return n * factorial(n - 1);
+}
+
+function exp_aux(n, acc) {
+    if (n == 0) return acc;
+    return exp_aux(n - 1, acc + (1  / factorial(n)));
+}
+
+function exp(n) {
+    return exp_aux(n, 1);    
+}
+
+let number f = exp(3000);

--- a/tests/profile.bash
+++ b/tests/profile.bash
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+echo "[Profiler] Running dune exec command..."
+
+# Start the application in the background
+dune exec lice ~/Code/Lice/tests/ &
+
+# Capture the PID of the last background process started
+APP_PID=$!
+
+# Wait for the application to fully start
+sleep 2
+
+echo "[Profiler] Profiling using gdbprofiler..."
+
+# Run gdbprofiler with the PID
+gdbprofiler -p $APP_PID --cpuprofile prof.cpuprofile --callgrind callgrind.out

--- a/tests/profile.bash
+++ b/tests/profile.bash
@@ -1,9 +1,21 @@
 #!/bin/bash
 
+function print_usage {
+    echo "Usage: $0 <path_to_tests>"
+    echo "Example: $0 lice_program.lice"
+}
+
+
+if [ $# -eq 0 ]; then
+    echo "[Profiler] No arguments provided. Please provide the path to the tests."
+    print_usage
+    exit 1
+fi
+
 echo "[Profiler] Running dune exec command..."
 
 # Start the application in the background
-dune exec lice ~/Code/Lice/tests/ &
+dune exec lice $1 &
 
 # Capture the PID of the last background process started
 APP_PID=$!
@@ -14,4 +26,4 @@ sleep 2
 echo "[Profiler] Profiling using gdbprofiler..."
 
 # Run gdbprofiler with the PID
-gdbprofiler -p $APP_PID --cpuprofile prof.cpuprofile --callgrind callgrind.out
+gdbprofiler -p $APP_PID --cpuprofile example.cpuprofile --callgrind callgrind.out


### PR DESCRIPTION
Related issue: https://github.com/gabyfle/Lice/issues/6

In this PR, I'm adding syntax for inline module definition.

You can now define a module:

```
module Math {
    let number pi = 3.14;

    function circlePerimeter(radius: number): number {
        return 2 * pi * radius;
    }
}
```

And then use it inside the same file:

```
let r = 5;

let perimeter = Math.circlePerimeter(r);
```